### PR TITLE
Enhanchement: option to continue processing if missing key encountered

### DIFF
--- a/src/ParameterPostProcessor.php
+++ b/src/ParameterPostProcessor.php
@@ -21,11 +21,18 @@ class ParameterPostProcessor
     private $parameters;
 
     /**
-     * @param array $parameters
+     * @var bool
      */
-    public function __construct(array $parameters)
+    private $continueOnError;
+
+    /**
+     * @param array $parameters
+     * @param bool $continueOnError If true processing is not interrupted when a non-existent key found
+     */
+    public function __construct(array $parameters, bool $continueOnError = false)
     {
         $this->parameters = $parameters;
+        $this->continueOnError = $continueOnError;
     }
 
     public function __invoke(array $config) : array
@@ -38,7 +45,10 @@ class ParameterPostProcessor
                 $value = $parameters->unescapeValue($parameters->resolveValue($value));
             });
         } catch (SymfonyParameterNotFoundException $exception) {
-            throw ParameterNotFoundException::fromException($exception);
+            // Skip throwing an exception if continue on error is enabled
+            if ($this->continueOnError !== true) {
+                throw ParameterNotFoundException::fromException($exception);
+            }
         }
 
         $config['parameters'] = $parameters->all();

--- a/test/ParameterPostProcessorTest.php
+++ b/test/ParameterPostProcessorTest.php
@@ -76,6 +76,13 @@ class ParameterPostProcessorTest extends TestCase
         $processor(['foo' => '%foo%']);
     }
 
+    public function testAllowsMissingParameter()
+    {
+        $processor = new ParameterPostProcessor([], true);
+        $processed = $processor(['foo' => '%foo%']);
+        $this->assertEquals('%foo%', $processed['foo']);
+    }
+
     public function testResolvesParameterizedParameters()
     {
         $processor = new ParameterPostProcessor([


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

**Why should it be added?**
Currently the library stops processing first time it encounters a missing configuration key. Some times it is not desirable and mising keys are not fatal. Eg. when processing is run multiple times at different stages. Eg. when processing is done at component config aggregation and during application level config aggregation in config/config.php. 

**What will it enable?**
This enhancement allows configuring the processor in a way that it continues processing if a missing key is encountered.

**How will the code be used?**
Constructor accepts a 2nd bool parameter, if set to true, processing is not interrupted with exception if an unknown configuration key is encountered.

**QA**
One additional test case is included to cover enhancement.
