### PR TITLE
lazy parameter processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#4](https://github.com/laminas/laminas-config-aggregator-parameters/pull/4) Added `LazyParameterPostProcessor` which can be used as a replacement for `ParameterPostProcessor` in case the parameters are loaded from i/o resources.
 
 ### Changed
 

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -84,7 +84,7 @@ array(5) {
 }
 ```
 
-## Parameter lazy loading
+## Parameter Lazy Loading
 
 If your parameters are resolved from a database, redis, consul, or any other i/o resource, you can use the `LazyParameterPostProcessor` which consumes just a `callable` which can provide the parameters.
 

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -83,3 +83,9 @@ array(5) {
   }
 }
 ```
+
+## Parameter lazy loading
+
+If your parameters are resolved from a database, redis, consul, or any other i/o resource, you can use the `LazyParameterPostProcessor` which consumes just a `callable` which can provide the parameters.
+
+In case you are using config-caching, the i/o is not executed when performed in the `callable`.

--- a/src/LazyParameterPostProcessor.php
+++ b/src/LazyParameterPostProcessor.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Laminas\ConfigAggregatorParameters;
+
+final class LazyParameterPostProcessor
+{
+    /**
+     * @var callable
+     */
+    private $parameterProvider;
+
+    /**
+     * @psalm-param callable():array<string,mixed> $parameterProvider
+     */
+    public function __construct(callable $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     *
+     * @return array<string,mixed>
+     */
+    public function __invoke(array $config): array
+    {
+        $parameterProvider = $this->parameterProvider;
+
+        return (new ParameterPostProcessor($parameterProvider()))($config);
+    }
+}

--- a/test/LazyParameterPostProcessorTest.php
+++ b/test/LazyParameterPostProcessorTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\ConfigAggregatorParameters;
+
+use Laminas\ConfigAggregatorParameters\LazyParameterPostProcessor;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class LazyParameterPostProcessorTest extends TestCase
+{
+    public function testParameterProviderNotCalledDuringInstantiation(): void
+    {
+        $callable = static function (): array {
+            throw new RuntimeException('Parameter provider must not be called during instantiation!');
+        };
+
+        new LazyParameterPostProcessor($callable);
+
+        self::assertTrue(true);
+    }
+
+    public function testParametersAreBeingProcessed(): void
+    {
+        $provider = static function (): array {
+            return ['foo' => 'bar'];
+        };
+
+        $config = [
+            'foo' => '%foo%',
+        ];
+
+        $processor = new LazyParameterPostProcessor($provider);
+        $processed = $processor($config);
+
+        self::assertEquals(['foo' => 'bar', 'parameters' => ['foo' => 'bar']], $processed);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| New Feature   | yes

### Description

In our projects, we are loading parameters takes i/o which is not necessary when the configuration is cached.
To resolve this, we have written a `callable` post-processor to wrap the original `ParameterPostProcessor`.

This is done in almost every project.

I've thought this is a good addition to the existing feature set of this package.