### PR TITLE
PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,30 +12,24 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
+      env:
+        - DEPS=latest
+    - php: 8.0
+      env:
+        - DEPS=lowest
+    - php: 8.0
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,17 @@
     "extra": {
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-config-aggregator": "^1.1",
         "laminas/laminas-stdlib": "^3.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "symfony/dependency-injection": "^3.4.36 || ^4.4.2 || ^5.0"
     },
     "require-dev": {
+        "dms/phpunit-arraysubset-asserts": "^0.2.1",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-config": "^3.1",
-        "phpunit/phpunit": "^7.5.17 || ^8.4.3"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="laminas-config-aggregator-parameters">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-config-aggregator-parameters">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/ParameterPostProcessorTest.php
+++ b/test/ParameterPostProcessorTest.php
@@ -10,12 +10,15 @@ declare(strict_types=1);
 
 namespace LaminasTest\ConfigAggregatorParameters;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Laminas\ConfigAggregatorParameters\ParameterNotFoundException;
 use Laminas\ConfigAggregatorParameters\ParameterPostProcessor;
 use PHPUnit\Framework\TestCase;
 
 class ParameterPostProcessorTest extends TestCase
 {
+    use ArraySubsetAsserts;
+
     public function parameterProvider()
     {
         return [


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Summary

To be prepared for the december release of PHP 8.0, this repository has some additional TODOs to be tested against the new major version.

In order to make this repository compatible, one has to follow these steps:

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x] Modify composer.json to drop support for PHP less than 7.3
- [x] Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
- [x] ~Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)~
- [x] Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
- [x] Modify source code in case there are incompatibilities with PHP 8.0

closes #8 